### PR TITLE
Update assets.js if soundsleft is equal to 0

### DIFF
--- a/code/FINAL/game/scripts/src/core/Asset.js
+++ b/code/FINAL/game/scripts/src/core/Asset.js
@@ -81,7 +81,7 @@
 			Asset.sound[event.id] = event.src;
 			console.log("Loaded sound "+event.id);
 			soundsLeft--;
-			if(soundsLeft==0){
+			if(soundsLeft===0){
 				allSoundsLoaded.resolve(true);
 			}
 		});


### PR DESCRIPTION
Caused crash when loading sounds for stage one in chrome Version 33.0.1750.154 m ; from NetBeans 7.4, updated operator to be equal to to make statement true., this is me first edit, please let me know if its good,
